### PR TITLE
vamp/parachord: use proper deallocator in getChordFeatures()

### DIFF
--- a/vamp/src/parachord.cpp
+++ b/vamp/src/parachord.cpp
@@ -220,7 +220,7 @@ Parachord::getChordFeatures()
         retFeatures[0].push_back(segmentToFeature(s));
     }
 
-    free(cd);
+    delete cd;
 
     return retFeatures;
 }


### PR DESCRIPTION
Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>