### PR TITLE
initial version of chromagram visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Default
 /build
 /doc/generated
+music-dsp-build

--- a/client/src/CMakeLists.txt
+++ b/client/src/CMakeLists.txt
@@ -1,7 +1,12 @@
+find_path(
+    SND_HEADERS
+    NAMES sndfile.h
+)
 set(SOURCES
     lmclient.cpp
 )
 
+include_directories(${SND_HEADERS})
 add_executable(${LMCLIENT_TARGET} ${SOURCES})
 add_dependencies(${LMCLIENT_TARGET} ${MUSIC_DSP_TARGET})
 


### PR DESCRIPTION
For now only 12-bin FFT-computed PCP vectors are produced, 24-bin CQT-based features on the way.