### PR TITLE
simple helper to dump intermediate data 

### DIFF
--- a/libmusic/include/lmhelpers.h
+++ b/libmusic/include/lmhelpers.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <fstream>
 
 #include "lmtypes.h"
 
@@ -122,6 +123,30 @@ public:
 
         return median;
     }
+
+    template<typename T>
+    static void lm_helpers_peep(const char *name, const std::vector<std::vector<T>> & matrix)
+    {
+        const char *path = getenv(name);
+        if (!path)
+            return;
+        std::ofstream csv(path, std::ios::out | std::ios::trunc);
+        if (csv.is_open()) {
+            for (auto &row : matrix) {
+                for (auto &value: row)
+                    csv << value << ",";
+                csv.seekp(-1, std::ios_base::end);
+                csv << std::endl;
+            }
+            csv.close();
+        }
+    }
 };
+
+#ifndef NDEBUG
+    #define LM_PEEP(name, var) Helpers::lm_helpers_peep(#name, (var))
+#else
+    #define LM_PEEP(name, var)
+#endif
 
 /** @} */

--- a/libmusic/src/cqt_wrapper.cpp
+++ b/libmusic/src/cqt_wrapper.cpp
@@ -23,7 +23,7 @@
 #include "CQParameters.h"
 
 #include "cqt_wrapper.h"
-
+#include "lmhelpers.h"
 
 namespace anatomist {
 
@@ -88,7 +88,7 @@ void CQTWrapper::Process(td_t td, uint32_t offset)
 
     output_block = cq_spectrogram_->getRemainingOutput();
     output.insert(output.end(), output_block.begin(), output_block.end());
-
+    LM_PEEP(CQTProcess_OUTPUT, output);
     output.erase(output.begin(), output.begin() + cq_spectrogram_->getLatency() /
                                                   cq_spectrogram_->getColumnHop());
 
@@ -126,9 +126,9 @@ log_spectrogram_t CQTWrapper::ConvertRealBlock_(CQBase::RealBlock &block)
 
         lsg.push_back(col);
     }
-
+    LM_PEEP(CQT_lsg, lsg);
     Denoise_(lsg);
-
+    LM_PEEP(CQT_lsg_denoised, lsg);
     return lsg;
 }
 


### PR DESCRIPTION
Implement simple helper to do a raw data dump to external CSV file.
The idea is to examine intermediate matrices or vectors, e.g. specters, at different stages of processing pipeline, with aim to do tuning or experiments.

Call to `LM_PEEK(name, data)` is put in that places in code where raw dump of `<data>` may be of any interest.
Then if code gets run with environment variable `<name>=<path/to/csv/file>` set, data gets written to that file, e.g.:

```
	$ LSG_denoised=lsg.csv ./bin/lmclient -c ../tests/test_sounds/chords_separate/C_chord_[..].wav
	 [...]
```

So for example we can load files in Octave and observe what smoothing does to spectrogram.

Before filtering:
![LSG_pre](https://user-images.githubusercontent.com/11311141/112737040-1e205580-8f60-11eb-87f4-3dba9275ebd0.png)
After median filtering:
![LSG_post](https://user-images.githubusercontent.com/11311141/112737045-2a0c1780-8f60-11eb-85d1-b0110a910592.png)

