### PR TITLE
libmusic: print slash chords in templates

### DIFF
--- a/libmusic/include/lmtypes.h
+++ b/libmusic/include/lmtypes.h
@@ -116,15 +116,18 @@ typedef struct Chord {
 
 private:
     note_t          __mRootNote;
+    note_t          __mBassNote;
     chord_quality_t __mQuality;
 
 public:
-    Chord(note_t n, chord_quality_t q) : __mRootNote(n), __mQuality(q) {}
+    Chord(note_t n, chord_quality_t q, note_t b = note_Unknown) : __mRootNote(n), __mBassNote(b), __mQuality(q) {}
     Chord() : Chord(note_Unknown, cq_unknown) {} // Delegate to the other constructor.
 
     friend bool operator==(const Chord &c1, const Chord &c2)
     {
-        return ((c1.__mRootNote == c2.__mRootNote) && (c1.__mQuality == c2.__mQuality));
+        return ((c1.__mRootNote == c2.__mRootNote)  &&
+                (c1.__mQuality == c2.__mQuality)    &&
+                (c1.__mBassNote == c2.__mBassNote));
     }
 
     friend bool operator!=(const Chord &c1, const Chord &c2)
@@ -145,6 +148,8 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const Chord &c)
     {
         os << c.__mRootNote << c.__mQuality;
+        if (c.__mBassNote != note_Unknown)
+            os << "/" << c.__mBassNote;
         return os;
     }
 
@@ -152,6 +157,8 @@ public:
     {
         std::ostringstream ss;
         ss << __mRootNote << __mQuality;
+        if (__mBassNote != note_Unknown)
+            ss << "/" << __mBassNote;
         return ss.str();
     }
 } chord_t;

--- a/libmusic/src/chord_tpl.cpp
+++ b/libmusic/src/chord_tpl.cpp
@@ -252,7 +252,7 @@ size_t ChordTpl::SlashSubtypesCnt(chord_quality_t q)
 
 ostream& operator<<(std::ostream& os, const ChordTpl& tpl)
 {
-    os << Chord(tpl.root_note_, tpl.chord_quality_);
+    os << Chord(tpl.root_note_, tpl.chord_quality_, tpl.bass_note_);
     for (auto &v : tpl.tpl_) {
         os << "," << v;
     }


### PR DESCRIPTION
Extend string representation of chord template with a bass note to distinguish its inversions, e.g:

```
	$ ./bin/Debug/lmclient --tplsdump | head -6
	C/C,2.3094,0,0,0,1.1547,0,0,1.1547,0,0,0,0,2.3094,0,0,0,2.3094,0,0,2.3094,0,0,0,0
	C,1.26491,0,0,0,1.26491,0,0,1.26491,0,0,0,0,2.52982,0,0,0,2.52982,0,0,2.52982,0,0,0,0
	C/E,1.1547,0,0,0,2.3094,0,0,1.1547,0,0,0,0,2.3094,0,0,0,2.3094,0,0,2.3094,0,0,0,0
	C/G,1.1547,0,0,0,1.1547,0,0,2.3094,0,0,0,0,2.3094,0,0,0,2.3094,0,0,2.3094,0,0,0,0
	Cm/C,2.3094,0,0,1.1547,0,0,0,1.1547,0,0,0,0,2.3094,0,0,2.3094,0,0,0,2.3094,0,0,0,0
	Cm,1.26491,0,0,1.26491,0,0,0,1.26491,0,0,0,0,2.52982,0,0,2.52982,0,0,0,2.52982,0,0,0,0
```