### PR TITLE
libmusic: improve (note_t) operator+

### DIFF
--- a/libmusic/include/lmtypes.h
+++ b/libmusic/include/lmtypes.h
@@ -70,7 +70,7 @@ typedef enum {
     notes_Total = note_Max - note_Min + 1
 } note_t;
 
-note_t& operator+(note_t& note, int32_t term);
+note_t operator+(note_t note, int term);
 std::ostream& operator<<(std::ostream& os, const note_t& n);
 
 typedef enum : int32_t {

--- a/libmusic/src/lmtypes.cpp
+++ b/libmusic/src/lmtypes.cpp
@@ -21,19 +21,16 @@
 #include "lmtypes.h"
 
 
-note_t& operator+(note_t& note, int32_t term)
+note_t operator+(note_t note, int term)
 {
-    int32_t tmp = static_cast<int32_t>(note) + term;
+    int tmp = static_cast<int>(note) + term % notes_Total;
 
-    if (tmp > note_Max) {
+    if (tmp > static_cast<int>(note_Max))
         tmp -= note_Max;
-    } else if (note < note_Min) {
+    else if (tmp < static_cast<int>(note_Min))
         tmp += note_Max;
-    }
 
-    note = static_cast<note_t>(tmp);
-
-    return note;
+    return static_cast<note_t>(tmp);
 }
 
 std::ostream& operator<<(std::ostream& os, const note_t& n)


### PR DESCRIPTION
Template chords sometimes are incomplete, e.g. for G#m:

  ```
 $ ./music-dsp-build/bin/Debug/lmclient --tplsdump|egrep '(G#m,)|(F#m,)'
   F#m,0,1.26491,0,0,0,0,1.26491,0,0,1.26491,0,0,0,2.52982,0,0,0,0,2.52982,0,0,2.52982,0,0
   G#m,0,0,0,1.54919,0,0,0,0,1.54919,0,0,0,0,0,0,3.09839,0,0,0,0,3.09839,0,0,0
```

In above example `F#m` template is complete, while `G#m` misses note `B`.
Root cause is overloaded note addition operator not handling note `B` and `C` correctly sometimes.