### PR TITLE
Pitch Class Sets support

### DIFF
--- a/client/src/lmclient.cpp
+++ b/client/src/lmclient.cpp
@@ -134,7 +134,7 @@ int main(int argc, char* argv[])
             usage();
             return 0;
         } else if (argv[i][0] == '-') {
-            cout << "Unrecognized option: " << argv[i] << endl;
+            cerr << "Unrecognized option: " << argv[i] << endl;
             usage();
             return 1;
         }
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
     /* Open input sound file */
     memset (&sfinfo, 0, sizeof (sfinfo)) ;
     if (!(sf = sf_open(inputFilePath, SFM_READ, &sfinfo))) {
-        cout << "Failed to open the file" << endl;
+        cerr << "Failed to open the file" << endl;
         return 1;
     }
 
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
     buf = (double*) malloc(itemsCnt * sizeof(double));
 
     if(!sf_read_double(sf, buf, itemsCnt)) {
-        cout << "Could not read file" << endl;
+        cerr << "Could not read file" << endl;
         return 1;
     }
 

--- a/libmusic/include/lmtypes.h
+++ b/libmusic/include/lmtypes.h
@@ -134,10 +134,12 @@ private:
     note_t          __mBassNote;
     int8_t          __mBassInterval;
     chord_quality_t __mQuality;
+    pcset_t         __mPCset;
 
 public:
     Chord(note_t n, chord_quality_t q, note_t b = note_Unknown, int8_t bi = -1) :
-        __mRootNote(n), __mBassNote(b),  __mBassInterval(bi), __mQuality(q) {}
+        __mRootNote(n), __mBassNote(b),  __mBassInterval(bi), __mQuality(q),
+        __mPCset(make_pcset(n, q)) {}
     Chord() : Chord(note_Unknown, cq_unknown) {} // Delegate to the other constructor.
 
     friend bool operator==(const Chord &c1, const Chord &c2)
@@ -161,6 +163,11 @@ public:
 
         return (((c1.__mRootNote != c2.__mRootNote) && (c1.__mRootNote < c2.__mRootNote)) ||
                 ((c1.__mRootNote == c2.__mRootNote) && (c1.__mQuality < c2.__mQuality)));
+    }
+
+    bool match(const Chord &c) const
+    {
+        return __mPCset == c.__mPCset;
     }
 
     std::string toHarte() const

--- a/libmusic/include/lmtypes.h
+++ b/libmusic/include/lmtypes.h
@@ -141,6 +141,7 @@ public:
         __mRootNote(n), __mBassNote(b),  __mBassInterval(bi), __mQuality(q),
         __mPCset(make_pcset(n, q)) {}
     Chord() : Chord(note_Unknown, cq_unknown) {} // Delegate to the other constructor.
+    Chord(const std::string &);
 
     friend bool operator==(const Chord &c1, const Chord &c2)
     {

--- a/libmusic/include/lmtypes.h
+++ b/libmusic/include/lmtypes.h
@@ -121,6 +121,10 @@ typedef enum {
     cq_Max = cq_min13
 } chord_quality_t;
 
+#include <unordered_set>
+typedef std::unordered_set<note_t, std::hash<int>> pcset_t;
+pcset_t make_pcset(note_t, chord_quality_t);
+
 std::ostream& operator<<(std::ostream& os, const chord_quality_t& q);
 
 typedef struct Chord {

--- a/libmusic/src/lmtypes.cpp
+++ b/libmusic/src/lmtypes.cpp
@@ -19,7 +19,7 @@
 
 #include "config.h"
 #include "lmtypes.h"
-
+#include "music_scale.h"
 
 note_t operator+(note_t note, int term)
 {
@@ -123,4 +123,43 @@ std::ostream& operator<<(std::ostream& os, const chord_quality_t& q)
     os << q2sMap[q];
 
     return os;
+}
+
+static std::map<chord_quality_t, const std::vector<std::pair<size_t, int>>> pctpls = {
+    {cq_maj,           {{2, 0}, {4, 0}                             }},
+    {cq_min,           {{2,-1}, {4, 0}                             }},
+    {cq_5,             {{4, 0}                                     }},
+    {cq_7,             {{2, 0}, {4, 0}, {6,-1}                     }},
+    {cq_maj7,          {{2, 0}, {4, 0}, {6, 0}                     }},
+    {cq_min7,          {{2,-1}, {4, 0}, {6,-1}                     }},
+    {cq_sus2,          {{1, 0}, {4, 0}                             }},
+    {cq_sus4,          {{3, 0}, {4, 0}                             }},
+    {cq_hdim7,         {{2,-1}, {4,-1}, {6,-1}                     }},
+    {cq_aug,           {{2, 0}, {4,+1}                             }},
+    {cq_dim,           {{2,-1}, {4,-1}                             }},
+    {cq_dim7,          {{2,-1}, {4,-1}, {6,-2}                     }},
+    {cq_maj_add9,      {{2, 0}, {4, 0}, {8, 0}                     }},
+    {cq_min_add9,      {{2,-1}, {4, 0}, {8, 0}                     }},
+    {cq_maj6,          {{2, 0}, {4, 0}, {5, 0}                     }},
+    {cq_min6,          {{2,-1}, {4, 0}, {5, 0}                     }},
+    {cq_maj9,          {{2, 0}, {4, 0}, {6, 0}, {8, 0}             }},
+    {cq_min9,          {{2,-1}, {4, 0}, {6,-1}, {8, 0}             }},
+    {cq_maj_add11,     {{2, 0}, {4, 0}, {10,0}                     }},
+    {cq_7_add9sharp,   {{2, 0}, {4, 0}, {6,-1}, {8,+1}             }},
+    {cq_9,             {{2, 0}, {4, 0}, {6,-1}, {8, 0}             }},
+    {cq_aug7,          {{2, 0}, {4,+1}, {6,-1}                     }},
+    {cq_maj11,         {{2, 0}, {4, 0}, {6, 0}, {8, 0},{10,0}      }},
+    {cq_min11,         {{2,-1}, {4, 0}, {6,-1}, {8, 0},{10,0}      }},
+    {cq_maj13,         {{2, 0}, {4, 0}, {6, 0}, {8, 0},{10,0},{12,0}}},
+    {cq_min13,         {{2,-1}, {4, 0}, {6,-1}, {8, 0},{10,0},{12,0}}},
+};
+
+pcset_t make_pcset(note_t root, chord_quality_t cq)
+{
+    auto scale = MusicScale::getMajorScale(root);
+    pcset_t pcset = { scale[0] };
+    const std::vector<std::pair<size_t, int>> & pctpl = pctpls[cq];
+    for (auto & E: pctpl)
+        pcset.insert(scale[E.first] + E.second);
+    return pcset;
 }

--- a/libmusic/src/lmtypes.cpp
+++ b/libmusic/src/lmtypes.cpp
@@ -21,6 +21,60 @@
 #include "lmtypes.h"
 #include "music_scale.h"
 
+Chord::Chord(const std::string &cs):
+    __mRootNote(note_Unknown), __mQuality(cq_unknown)
+{
+    const bool is_sharp = cs.length() > 1 && cs[1] == '#';
+    std::string cn = cs.substr(0, cs.find("/"));
+
+    switch (cs[0]) {
+        case 'C': __mRootNote = is_sharp ? note_C_sharp: note_C; break;
+        case 'D': __mRootNote = is_sharp ? note_D_sharp: note_D; break;
+        case 'E': __mRootNote = note_E; break;
+        case 'F': __mRootNote = is_sharp ? note_F_sharp: note_F; break;
+        case 'G': __mRootNote = is_sharp ? note_G_sharp: note_G; break;
+        case 'A': __mRootNote = is_sharp ? note_A_sharp: note_A; break;
+        case 'B': __mRootNote = note_B; break;
+        default:
+            throw std::runtime_error("can't parse " + cs);
+    }
+    cn.erase(0, is_sharp ? 2 : 1);
+    if (cn[0] == ':')
+        cn.erase(0,1);
+    static const std::map<const std::string,const chord_quality_t> s2cq {
+        {"maj", cq_maj}, {"", cq_maj},
+        {"min", cq_min}, {"m", cq_min},
+        {"5", cq_5},
+        {"7", cq_7},
+        {"maj7", cq_maj7},
+        {"min7", cq_min7}, {"m7", cq_min7},
+        {"sus2", cq_sus2},
+        {"sus4", cq_sus4},
+        {"hdim7", cq_hdim7}, {"m7b5", cq_hdim7},
+        {"aug", cq_aug},
+        {"dim", cq_dim},
+        {"dim7", cq_dim7},
+        {"maj(9)", cq_maj_add9}, {"add9", cq_maj_add9},
+        {"min(9)", cq_min_add9}, {"m(add9)", cq_min_add9},
+        {"maj6", cq_maj6}, {"6", cq_maj6},
+        {"min6", cq_min6}, {"m6", cq_min6},
+        {"maj9", cq_maj9},
+        {"min9", cq_min9}, {"m9", cq_min9},
+        {"maj(11)", cq_maj_add11}, {"add11", cq_maj_add11},
+        {"9", cq_9},
+        {"aug7", cq_aug7},
+        {"maj11", cq_maj11},
+        {"min11", cq_min11}, {"m11", cq_min11},
+        {"maj13", cq_maj13},
+        {"min13", cq_min13}, {"m13", cq_min13},
+    };
+
+    if (s2cq.find(cn) == s2cq.end())
+        throw std::runtime_error("can't parse " + cs);
+    __mQuality = s2cq.at(cn);
+    __mPCset = make_pcset(__mRootNote, __mQuality);
+}
+
 note_t operator+(note_t note, int term)
 {
     int tmp = static_cast<int>(note) + term % notes_Total;


### PR DESCRIPTION
Implement support of Pitch Class Sets and use them as basis for precision-scoring.
The major idea of pcset is that the same pitch classes may form several chords, e.g. both Dsus2 and Asus4/D have the same pitch classes D, E, A and basically are indistinguishable.   

References:
  Christopher Harte, Towards Automatic Extraction of Harmony Information from Music Signals, §5.2.3