### PR TITLE
libmusic: pcp: fix semitone weighting

### DIFF
--- a/libmusic/src/pitch_cls_profile.cpp
+++ b/libmusic/src/pitch_cls_profile.cpp
@@ -95,7 +95,7 @@ PitchClsProfile::PitchClsProfile(fd_t &fd_mags, tft_t *tft)
         note_t note;
         amplitude_t tmp = 0;
         for (int32_t i = -bps/2; i < bps/2+1; i++) {
-            tmp += fd_mags[bin + i] * (1 - abs(i * 1.0 / (i/2 + 1)));
+            tmp += fd_mags[bin + i] * (1 - abs(i * 1.0 / (bps/2 + 1)));
         }
 
         if (0 == tmp)


### PR DESCRIPTION
Obviously a triangle function with base width of `bps` must be applied here.
![tri](https://user-images.githubusercontent.com/11311141/151709255-e90f3b97-d470-4233-b2da-8ff428464c3d.png)

